### PR TITLE
Revert "Create CNAME"

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-juliastats.org


### PR DESCRIPTION
I'm unable to reach juliastats.org or juliastats.github.org after this merge -- just redirected back and forth between the two sites.
