### PR TITLE
index.html: remove link to obsolete roadmap

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,7 +268,6 @@
 					</header>
 					<p><strong>Forum</strong>: <a href="https://discourse.julialang.org/c/domain/stats">Statistics topic on the Julia Discourse</a></p>
 					<p><strong>Github page</strong>: <a href="https://github.com/JuliaStats">https://github.com/JuliaStats</a></p>
-					<p>We discuss our <strong>blueprints</strong> on <a href="https://github.com/JuliaStats/Roadmap.jl">Roadmap.jl</a>.
 				</article>
 			</div>
 


### PR DESCRIPTION
If you want to keep the rule of three you could have a link to slack instead?